### PR TITLE
Add route/focus UI and boundary overlays to maps

### DIFF
--- a/lib/components/HWasteCollectionMap.tsx
+++ b/lib/components/HWasteCollectionMap.tsx
@@ -1,8 +1,10 @@
-import React, { useMemo, useRef, useEffect } from 'react';
-import { View, Text, Image, StyleSheet } from 'react-native';
-import MapView, { Marker, Callout, UrlTile, Region } from 'react-native-maps';
+import React, { useMemo, useRef, useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import WasteIcon from './WasteIcon';
+import MapView, { Marker, Callout, UrlTile, Region, Polygon, Polyline } from 'react-native-maps';
 import tw from '../utils/tailwind';
 import { API_BASE } from '../services/apiClient';
+import { getCachedBoundary, setCachedBoundary } from '../utils/boundaryCache';
 import type { WasteContainer } from '../services/wasteContainerService';
 
 type Props = {
@@ -12,6 +14,25 @@ type Props = {
   onUserLocationChange?: (coords: { latitude: number; longitude: number; accuracy?: number }) => void;
   userLocation?: { latitude: number; longitude: number } | null;
   recenterKey?: number;
+  routePath?: { latitude: number; longitude: number }[] | null;
+  focusCoords?: { latitude: number; longitude: number } | null;
+};
+
+const BARANGAY_176_QUERIES = [
+  { key: '176-e', label: 'Barangay 176-E', query: 'Barangay 176-E, Caloocan, Metro Manila, Philippines', color: '#1B5E20', fillColor: '#A5D6A7' },
+  { key: '176-a', label: 'Barangay 176-A', query: 'Barangay 176-A, Caloocan, Metro Manila, Philippines', color: '#2E7D32', fillColor: '#B7E1B0' },
+  { key: '176-b', label: 'Barangay 176-B', query: 'Barangay 176-B, Caloocan, Metro Manila, Philippines', color: '#388E3C', fillColor: '#C8E6C9' },
+  { key: '176-c', label: 'Barangay 176-C', query: 'Barangay 176-C, Caloocan, Metro Manila, Philippines', color: '#43A047', fillColor: '#D1EFD0' },
+  { key: '176-d', label: 'Barangay 176-D', query: 'Barangay 176-D, Caloocan, Metro Manila, Philippines', color: '#4CAF50', fillColor: '#DDF5D8' },
+  { key: '176-f', label: 'Barangay 176-F', query: 'Barangay 176-F, Caloocan, Metro Manila, Philippines', color: '#5FBF5B', fillColor: '#E6F7E3' },
+];
+
+type PolygonBoundary = {
+  key: string;
+  label: string;
+  color: string;
+  fillColor: string;
+  polygons: { latitude: number; longitude: number }[][];
 };
 
 export default function HWasteCollectionMap({
@@ -21,8 +42,12 @@ export default function HWasteCollectionMap({
   onUserLocationChange,
   userLocation,
   recenterKey = 0,
+  routePath = null,
+  focusCoords = null,
 }: Props) {
   const mapRef = useRef<MapView | null>(null);
+  const [boundaries, setBoundaries] = useState<PolygonBoundary[]>([]);
+  const skipBoundaryFitRef = useRef(false);
 
   const initialRegion: Region = useMemo(() => {
     const first = containers.find(c => Number.isFinite(c.latitude) && Number.isFinite(c.longitude));
@@ -57,6 +82,102 @@ export default function HWasteCollectionMap({
     );
   }, [userLocation, recenterKey]);
 
+  useEffect(() => {
+    if (!mapRef.current || !routePath || routePath.length < 2) return;
+    mapRef.current.fitToCoordinates(routePath, {
+      edgePadding: { top: 60, right: 60, bottom: 80, left: 60 },
+      animated: true,
+    });
+  }, [routePath]);
+
+  useEffect(() => {
+    if (!mapRef.current || !focusCoords) return;
+    mapRef.current.animateToRegion(
+      {
+        latitude: focusCoords.latitude,
+        longitude: focusCoords.longitude,
+        latitudeDelta: 0.01,
+        longitudeDelta: 0.01,
+      },
+      500
+    );
+  }, [focusCoords]);
+
+  useEffect(() => {
+    if (recenterKey > 0) skipBoundaryFitRef.current = true;
+  }, [recenterKey]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const fetchBoundary = async (query: string) => {
+      const cached = await getCachedBoundary(query);
+      if (cached) return cached;
+
+      const url = `https://nominatim.openstreetmap.org/search?format=geojson&polygon_geojson=1&limit=1&q=${encodeURIComponent(
+        query
+      )}`;
+      const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
+      if (!res.ok) return null;
+      const data = await res.json();
+      const feature = data?.features?.[0] ?? null;
+      if (feature) await setCachedBoundary(query, feature);
+      return feature;
+    };
+
+    const toPolygons = (feature: any): { latitude: number; longitude: number }[][] => {
+      if (!feature?.geometry) return [];
+      const geom = feature.geometry;
+      if (geom.type === 'Polygon') {
+        const rings = geom.coordinates as number[][][];
+        return rings.map((ring) => ring.map((p) => ({ latitude: p[1], longitude: p[0] })));
+      }
+      if (geom.type === 'MultiPolygon') {
+        const polys = geom.coordinates as number[][][][];
+        return polys.flatMap((poly) =>
+          poly.map((ring) => ring.map((p) => ({ latitude: p[1], longitude: p[0] })))
+        );
+      }
+      return [];
+    };
+
+    const fitToBoundary = (coords: { latitude: number; longitude: number }[]) => {
+      if (!mapRef.current || coords.length === 0) return;
+      mapRef.current.fitToCoordinates(coords, {
+        edgePadding: { top: 40, right: 40, bottom: 40, left: 40 },
+        animated: true,
+      });
+    };
+
+    const run = async () => {
+      try {
+        const results: PolygonBoundary[] = [];
+        for (const b of BARANGAY_176_QUERIES) {
+          const feature = await fetchBoundary(b.query);
+          if (!mounted) return;
+          const polygons = toPolygons(feature);
+          if (polygons.length) {
+            results.push({ key: b.key, label: b.label, color: b.color, fillColor: b.fillColor, polygons });
+          }
+        }
+        if (!mounted) return;
+        setBoundaries(results);
+
+        const brgy176e = results.find((r) => r.key === '176-e');
+        const flat = brgy176e?.polygons?.flat() ?? [];
+        if (flat.length && !skipBoundaryFitRef.current) fitToBoundary(flat);
+      } catch {
+        if (!mounted) return;
+        setBoundaries([]);
+      }
+    };
+
+    run();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
   // ✅ Choose tile source
   const tileUrl = useMemo(() => {
     const backendUrl = `${API_BASE.replace(/\/$/, '')}/api/map/tiles/{z}/{x}/{y}.png`;
@@ -87,21 +208,51 @@ export default function HWasteCollectionMap({
       >
         <UrlTile urlTemplate={tileUrl} maximumZ={19} />
 
-        {containers.map((c) => (
-          <Marker
-            key={String(c.id)}
-            coordinate={{ latitude: c.latitude, longitude: c.longitude }}
-            tracksViewChanges={false}
-          >
-            <Image source={require('../../assets/trashcan.png')} style={tw`w-7 h-7`} />
-            <Callout>
-              <View style={tw`min-w-40 py-1`}>
-                <Text style={tw`text-[13px] font-bold text-primary`}>{c.areaName}</Text>
-                <Text style={tw`text-xs text-primary`}>{c.name}</Text>
+        {boundaries.map((b) =>
+          b.polygons.map((ring, idx) => (
+            <Polygon
+              key={`${b.key}-${idx}`}
+              coordinates={ring}
+              strokeColor={b.color}
+              strokeWidth={b.key === '176-e' ? 3 : 2}
+              fillColor={b.key === '176-e' ? `${b.fillColor}A0` : `${b.fillColor}80`}
+            />
+          ))
+        )}
+
+        {routePath && routePath.length >= 2 && (
+          <Polyline
+            coordinates={routePath}
+            strokeColor="#2E523A"
+            strokeWidth={4}
+            lineCap="round"
+            lineJoin="round"
+          />
+        )}
+
+        {containers.map((c, i) => {
+          const lat = Number(c.latitude);
+          const lon = Number(c.longitude);
+          if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+          const key = String(c.id ?? c.container_id ?? `${lat}-${lon}-${i}`);
+          return (
+            <Marker
+              key={key}
+              coordinate={{ latitude: lat, longitude: lon }}
+              tracksViewChanges={false}
+            >
+              <View style={styles.markerWrap}>
+                <WasteIcon size={28} />
               </View>
-            </Callout>
-          </Marker>
-        ))}
+              <Callout>
+                <View style={tw`min-w-40 py-1`}>
+                  <Text style={tw`text-[13px] font-bold text-primary`}>{c.areaName}</Text>
+                  <Text style={tw`text-xs text-primary`}>{c.name}</Text>
+                </View>
+              </Callout>
+            </Marker>
+          );
+        })}
 
         {userLocation && (
           <Marker coordinate={userLocation} tracksViewChanges={false}>
@@ -117,3 +268,7 @@ export default function HWasteCollectionMap({
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  markerWrap: { alignItems: 'center', justifyContent: 'center' },
+});

--- a/lib/components/OWasteCollectionMap.tsx
+++ b/lib/components/OWasteCollectionMap.tsx
@@ -1,7 +1,9 @@
 import React, { useMemo, useRef, useEffect, useState } from 'react';
-import { View, Text, StyleSheet, Image, Alert } from 'react-native';
-import MapView, { Marker, Callout, UrlTile, Region } from 'react-native-maps';
+import { View, Text, StyleSheet, Alert } from 'react-native';
+import WasteIcon from './WasteIcon';
+import MapView, { Marker, Callout, UrlTile, Region, Polygon, Polyline } from 'react-native-maps';
 import { API_BASE } from '../services/apiClient';
+import { getCachedBoundary, setCachedBoundary } from '../utils/boundaryCache';
 import type { WasteContainer } from '../services/wasteContainerService';
 
 type Props = {
@@ -11,6 +13,24 @@ type Props = {
   onUserLocationChange?: (coords: { latitude: number; longitude: number; accuracy?: number }) => void;
   userLocation?: { latitude: number; longitude: number } | null;
   recenterKey?: number;
+  routePath?: { latitude: number; longitude: number }[] | null;
+};
+
+const BARANGAY_176_QUERIES = [
+  { key: '176-e', label: 'Barangay 176-E', query: 'Barangay 176-E, Caloocan, Metro Manila, Philippines', color: '#1B5E20', fillColor: '#A5D6A7' },
+  { key: '176-a', label: 'Barangay 176-A', query: 'Barangay 176-A, Caloocan, Metro Manila, Philippines', color: '#2E7D32', fillColor: '#B7E1B0' },
+  { key: '176-b', label: 'Barangay 176-B', query: 'Barangay 176-B, Caloocan, Metro Manila, Philippines', color: '#388E3C', fillColor: '#C8E6C9' },
+  { key: '176-c', label: 'Barangay 176-C', query: 'Barangay 176-C, Caloocan, Metro Manila, Philippines', color: '#43A047', fillColor: '#D1EFD0' },
+  { key: '176-d', label: 'Barangay 176-D', query: 'Barangay 176-D, Caloocan, Metro Manila, Philippines', color: '#4CAF50', fillColor: '#DDF5D8' },
+  { key: '176-f', label: 'Barangay 176-F', query: 'Barangay 176-F, Caloocan, Metro Manila, Philippines', color: '#5FBF5B', fillColor: '#E6F7E3' },
+];
+
+type PolygonBoundary = {
+  key: string;
+  label: string;
+  color: string;
+  fillColor: string;
+  polygons: { latitude: number; longitude: number }[][];
 };
 
 export default function OWasteCollectionMap({
@@ -20,9 +40,12 @@ export default function OWasteCollectionMap({
   onUserLocationChange,
   userLocation,
   recenterKey = 0,
+  routePath = null,
 }: Props) {
   const mapRef = useRef<MapView | null>(null);
   const [useBackendTiles, setUseBackendTiles] = useState<boolean | null>(null);
+  const [boundaries, setBoundaries] = useState<PolygonBoundary[]>([]);
+  const skipBoundaryFitRef = useRef(false);
 
   // probe backend once (fast timeout) and decide tile source
   useEffect(() => {
@@ -112,6 +135,89 @@ export default function OWasteCollectionMap({
     );
   }, [userLocation, recenterKey]);
 
+  useEffect(() => {
+    if (!mapRef.current || !routePath || routePath.length < 2) return;
+    mapRef.current.fitToCoordinates(routePath, {
+      edgePadding: { top: 60, right: 60, bottom: 80, left: 60 },
+      animated: true,
+    });
+  }, [routePath]);
+
+  useEffect(() => {
+    if (recenterKey > 0) skipBoundaryFitRef.current = true;
+  }, [recenterKey]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const fetchBoundary = async (query: string) => {
+      const cached = await getCachedBoundary(query);
+      if (cached) return cached;
+
+      const url = `https://nominatim.openstreetmap.org/search?format=geojson&polygon_geojson=1&limit=1&q=${encodeURIComponent(
+        query
+      )}`;
+      const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
+      if (!res.ok) return null;
+      const data = await res.json();
+      const feature = data?.features?.[0] ?? null;
+      if (feature) await setCachedBoundary(query, feature);
+      return feature;
+    };
+
+    const toPolygons = (feature: any): { latitude: number; longitude: number }[][] => {
+      if (!feature?.geometry) return [];
+      const geom = feature.geometry;
+      if (geom.type === 'Polygon') {
+        const rings = geom.coordinates as number[][][];
+        return rings.map((ring) => ring.map((p) => ({ latitude: p[1], longitude: p[0] })));
+      }
+      if (geom.type === 'MultiPolygon') {
+        const polys = geom.coordinates as number[][][][];
+        return polys.flatMap((poly) =>
+          poly.map((ring) => ring.map((p) => ({ latitude: p[1], longitude: p[0] })))
+        );
+      }
+      return [];
+    };
+
+    const fitToBoundary = (coords: { latitude: number; longitude: number }[]) => {
+      if (!mapRef.current || coords.length === 0) return;
+      mapRef.current.fitToCoordinates(coords, {
+        edgePadding: { top: 40, right: 40, bottom: 40, left: 40 },
+        animated: true,
+      });
+    };
+
+    const run = async () => {
+      try {
+        const results: PolygonBoundary[] = [];
+        for (const b of BARANGAY_176_QUERIES) {
+          const feature = await fetchBoundary(b.query);
+          if (!mounted) return;
+          const polygons = toPolygons(feature);
+          if (polygons.length) {
+            results.push({ key: b.key, label: b.label, color: b.color, fillColor: b.fillColor, polygons });
+          }
+        }
+        if (!mounted) return;
+        setBoundaries(results);
+
+        const brgy176e = results.find((r) => r.key === '176-e');
+        const flat = brgy176e?.polygons?.flat() ?? [];
+        if (flat.length && !skipBoundaryFitRef.current) fitToBoundary(flat);
+      } catch {
+        if (!mounted) return;
+        setBoundaries([]);
+      }
+    };
+
+    run();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
   return (
     <View style={styles.wrap}>
       <MapView
@@ -146,22 +252,45 @@ export default function OWasteCollectionMap({
           zIndex={0}
         />
 
+        {boundaries.map((b) =>
+          b.polygons.map((ring, idx) => (
+            <Polygon
+              key={`${b.key}-${idx}`}
+              coordinates={ring}
+              strokeColor={b.color}
+              strokeWidth={b.key === '176-e' ? 3 : 2}
+              fillColor={b.key === '176-e' ? `${b.fillColor}A0` : `${b.fillColor}80`}
+            />
+          ))
+        )}
+
+        {routePath && routePath.length >= 2 && (
+          <Polyline
+            coordinates={routePath}
+            strokeColor="#2E523A"
+            strokeWidth={4}
+            lineCap="round"
+            lineJoin="round"
+          />
+        )}
+
         {/* containers */}
-        {containers.map((c) => (
+        {containers.map((c, i) => {
+          const lat = Number(c.latitude);
+          const lon = Number(c.longitude);
+          if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+          const key = String(c.id ?? c.container_id ?? `${lat}-${lon}-${i}`);
+          return (
           <Marker
-            key={c.id}
-            coordinate={{ latitude: c.latitude, longitude: c.longitude }}
+            key={key}
+            coordinate={{ latitude: lat, longitude: lon }}
             title={c.name || c.areaName || 'Container'}
             description={c.fullAddress ?? undefined}
             tracksViewChanges={false}
           >
-            {/* lightweight marker icon (falls back to default pin if asset missing) */}
-            <Image
-              // marker-waste.png was missing in the bundle — use trashcan.png which exists
-              source={require('../../assets/trashcan.png')}
-              style={styles.markerIcon}
-              resizeMode="contain"
-            />
+            <View style={styles.markerWrap}>
+              <WasteIcon size={28} />
+            </View>
             <Callout tooltip>
               <View style={styles.callout}>
                 <Text style={styles.calloutTitle}>{c.areaName ?? c.name}</Text>
@@ -170,7 +299,8 @@ export default function OWasteCollectionMap({
               </View>
             </Callout>
           </Marker>
-        ))}
+          );
+        })}
       </MapView>
 
       {containers.length === 0 && (
@@ -184,6 +314,7 @@ export default function OWasteCollectionMap({
 
 const styles = StyleSheet.create({
   wrap: { flex: 1, backgroundColor: '#fff' },
+  markerWrap: { alignItems: 'center', justifyContent: 'center' },
   markerIcon: { width: 32, height: 32, tintColor: '#2E523A' },
   callout: { width: 180, padding: 8, backgroundColor: '#fff', borderRadius: 8, elevation: 3 },
   calloutTitle: { fontWeight: '700', color: '#2E523A', marginBottom: 4 },

--- a/lib/components/OWasteCollectionMap.web.tsx
+++ b/lib/components/OWasteCollectionMap.web.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef } from 'react';
-import { View, StyleSheet, Image } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { API_BASE } from '../services/apiClient';
+import { getCachedBoundary, setCachedBoundary } from '../utils/boundaryCache';
 import type { WasteContainer } from '../services/wasteContainerService';
 
 type Props = {
@@ -10,6 +11,7 @@ type Props = {
   onUserLocationChange?: (coords: { latitude: number; longitude: number; accuracy?: number }) => void;
   userLocation?: { latitude: number; longitude: number } | null;
   recenterKey?: number;
+  routePath?: { latitude: number; longitude: number }[] | null;
 };
 
 const ensureLeafletCss = () => {
@@ -29,32 +31,48 @@ export default function OWasteCollectionMap({
   interactive = true,
   userLocation,
   recenterKey = 0,
+  routePath = null,
 }: Props) {
   const mapHostRef = useRef<any>(null);
+  const mapInstanceRef = useRef<any>(null);
+  const leafletRef = useRef<any>(null);
+  const boundaryLayersRef = useRef<any[]>([]);
+  const markerLayersRef = useRef<any[]>([]);
+  const youLayerRef = useRef<any>(null);
+  const routeLayerRef = useRef<any>(null);
+  const skipBoundaryFitRef = useRef(false);
 
   const iconUrl = useMemo(() => {
-    try {
-      return Image.resolveAssetSource(require('../../assets/trashcan.png')).uri;
-    } catch {
-      return undefined;
-    }
+    const svg = `
+      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none">
+        <path fill="#355842" d="M9 2L8 3H4V5H20V3H16L15 2H9ZM5 7V21C5 22.1 5.9 23 7 23H17C18.1 23 19 22.1 19 21V7H5ZM9 9H11V21H9V9ZM13 9H15V21H13V9Z"/>
+      </svg>
+    `;
+    return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
   }, []);
 
   useEffect(() => {
+    if (typeof document === 'undefined') return;
     let cancelled = false;
     let map: any;
+    let mountEl: HTMLDivElement | null = null;
 
     const mount = async () => {
       ensureLeafletCss();
 
       const hostEl = mapHostRef.current as any;
-      if (!hostEl) return;
+      if (!hostEl || typeof hostEl.appendChild !== 'function') return;
 
       hostEl.innerHTML = '';
+      mountEl = document.createElement('div');
+      mountEl.style.width = '100%';
+      mountEl.style.height = '100%';
+      hostEl.appendChild(mountEl);
 
       const Lmod: any = await import('leaflet');
       const L = Lmod?.default ?? Lmod;
       if (cancelled) return;
+      leafletRef.current = L;
 
       const mapOptions: any = {
         zoomControl: interactive,
@@ -62,14 +80,16 @@ export default function OWasteCollectionMap({
         scrollWheelZoom: interactive,
         doubleClickZoom: interactive,
         touchZoom: interactive,
+        zoomAnimation: false,
+        fadeAnimation: false,
+        markerZoomAnimation: false,
+        inertia: false,
       };
 
-      map = L.map(hostEl, mapOptions);
-
-      L.tileLayer(`${API_BASE.replace(/\/$/, '')}/api/map/tiles/{z}/{x}/{y}.png`, {
-        maxZoom: 19,
-        attribution: '&copy; OpenStreetMap contributors',
-      }).addTo(map);
+      map = L.map(mountEl, mapOptions);
+      mapInstanceRef.current = map;
+      // Ensure map has a base view before any interactions
+      map.setView([14.5995, 120.9842], 12, { animate: false });
 
       const icon =
         iconUrl
@@ -81,45 +101,92 @@ export default function OWasteCollectionMap({
             })
           : undefined;
 
-      const bounds = L.latLngBounds([]);
+      const BARANGAY_176_QUERIES = [
+        { key: '176-e', label: 'Barangay 176-E', query: 'Barangay 176-E, Caloocan, Metro Manila, Philippines', color: '#1B5E20', fillColor: '#A5D6A7' },
+        { key: '176-a', label: 'Barangay 176-A', query: 'Barangay 176-A, Caloocan, Metro Manila, Philippines', color: '#2E7D32', fillColor: '#B7E1B0' },
+        { key: '176-b', label: 'Barangay 176-B', query: 'Barangay 176-B, Caloocan, Metro Manila, Philippines', color: '#388E3C', fillColor: '#C8E6C9' },
+        { key: '176-c', label: 'Barangay 176-C', query: 'Barangay 176-C, Caloocan, Metro Manila, Philippines', color: '#43A047', fillColor: '#D1EFD0' },
+        { key: '176-d', label: 'Barangay 176-D', query: 'Barangay 176-D, Caloocan, Metro Manila, Philippines', color: '#4CAF50', fillColor: '#DDF5D8' },
+        { key: '176-f', label: 'Barangay 176-F', query: 'Barangay 176-F, Caloocan, Metro Manila, Philippines', color: '#5FBF5B', fillColor: '#E6F7E3' },
+      ];
 
-      (containers || []).forEach((c) => {
-        const lat = Number(c.latitude);
-        const lon = Number(c.longitude);
-        if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
+      const fetchBoundary = async (query: string) => {
+        const cached = await getCachedBoundary(query);
+        if (cached) return cached;
 
-        const latLng = L.latLng(lat, lon);
-        bounds.extend(latLng);
+        const url = `https://nominatim.openstreetmap.org/search?format=geojson&polygon_geojson=1&limit=1&q=${encodeURIComponent(
+          query
+        )}`;
+        const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
+        if (!res.ok) return null;
+        const data = await res.json();
+        const feature = data?.features?.[0] ?? null;
+        if (feature) await setCachedBoundary(query, feature);
+        return feature;
+      };
 
-        const marker = L.marker(latLng, icon ? { icon } : undefined).addTo(map);
-        marker.bindPopup(`<div style="font-size:12px">
-            <div style="font-weight:700">${c.areaName ?? ''}</div>
-            <div>${c.name ?? ''}</div>
-          </div>`);
-      });
-
-      if (userLocation) {
-        const youIcon = L.divIcon({
-          className: 'you-marker',
-          html: `
-            <div style="display:flex;flex-direction:column;align-items:center;">
-              <div style="width:10px;height:10px;background:#2E523A;border:2px solid #fff;border-radius:999px;"></div>
-              <div style="margin-top:4px;background:rgba(255,255,255,.9);padding:2px 6px;border-radius:999px;border:1px solid #e5e7eb;font-size:10px;font-weight:600;color:#374151;">
-                You
-              </div>
-            </div>
-          `,
+      const clearBoundaryLayers = () => {
+        boundaryLayersRef.current.forEach((layer) => {
+          try { layer.remove(); } catch {}
         });
-        L.marker([userLocation.latitude, userLocation.longitude], { icon: youIcon }).addTo(map);
-      }
+        boundaryLayersRef.current = [];
+      };
 
-      if (userLocation) {
-        map.setView([userLocation.latitude, userLocation.longitude], 16);
-      } else if (bounds.isValid()) {
-        map.fitBounds(bounds, { padding: [24, 24], maxZoom: 17 });
-      } else {
-        map.setView([14.5995, 120.9842], 12);
-      }
+      const renderBoundaries = async () => {
+        clearBoundaryLayers();
+        let fitTarget: any = null;
+        for (const b of BARANGAY_176_QUERIES) {
+          if (cancelled || !map || !map._container) return;
+          const feature = await fetchBoundary(b.query);
+          if (cancelled || !map || !map._container) return;
+          if (!feature?.geometry) continue;
+
+          if (!map.getPane || !map.getPane('overlayPane')) return;
+
+          const layer = L.geoJSON(feature, {
+            style: {
+              color: b.color,
+              weight: b.key === '176-e' ? 3 : 2,
+              opacity: 0.9,
+              fillColor: b.fillColor,
+              fillOpacity: b.key === '176-e' ? 0.45 : 0.3,
+            },
+          });
+          if (!map || !map._container) return;
+          layer.addTo(map);
+          boundaryLayersRef.current.push(layer);
+          if (b.key === '176-e') fitTarget = layer;
+        }
+
+        if (fitTarget && !skipBoundaryFitRef.current && map && map._container && map._loaded) {
+          const fitBounds = fitTarget.getBounds();
+          const size = map.getSize ? map.getSize() : null;
+          if (fitBounds?.isValid() && size && size.x > 0 && size.y > 0) {
+            try {
+              map.fitBounds(fitBounds, { padding: [24, 24], maxZoom: 16, animate: false });
+            } catch {
+              // ignore
+            }
+          }
+        }
+      };
+
+      map.whenReady(async () => {
+        if (!map || !map._container) return;
+
+        try {
+          map.invalidateSize();
+        } catch {
+          // ignore
+        }
+
+        L.tileLayer(`${API_BASE.replace(/\/$/, '')}/api/map/tiles/{z}/{x}/{y}.png`, {
+          maxZoom: 19,
+          attribution: '&copy; OpenStreetMap contributors',
+        }).addTo(map);
+
+        await renderBoundaries();
+      });
     };
 
     mount();
@@ -127,12 +194,118 @@ export default function OWasteCollectionMap({
     return () => {
       cancelled = true;
       try {
-        if (map) map.remove();
+        if (map) {
+          try { map.stop(); } catch {}
+          try { map.off(); } catch {}
+          map.remove();
+        }
+      } catch {
+        // ignore
+      }
+      mapInstanceRef.current = null;
+      leafletRef.current = null;
+      markerLayersRef.current = [];
+      youLayerRef.current = null;
+      routeLayerRef.current = null;
+      try {
+        if (mountEl && mountEl.parentElement) mountEl.parentElement.removeChild(mountEl);
       } catch {
         // ignore
       }
     };
-  }, [containers, interactive, iconUrl, userLocation, recenterKey]);
+  }, [interactive, iconUrl]);
+
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    const L = leafletRef.current;
+    if (!map || !L || !map._container || !map._loaded) return;
+
+    // clear existing markers
+    markerLayersRef.current.forEach((layer) => {
+      try { layer.remove(); } catch {}
+    });
+    markerLayersRef.current = [];
+
+    (containers || []).forEach((c, i) => {
+      const lat = Number(c.latitude);
+      const lon = Number(c.longitude);
+      if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
+
+      const marker = L.marker(
+        [lat, lon],
+        iconUrl
+          ? {
+              icon: L.icon({
+                iconUrl,
+                iconSize: [28, 28],
+                iconAnchor: [14, 28],
+                popupAnchor: [0, -28],
+              }),
+            }
+          : undefined
+      ).addTo(map);
+
+      marker.bindPopup(`<div style="font-size:12px">
+          <div style="font-weight:700">${c.areaName ?? ''}</div>
+          <div>${c.name ?? ''}</div>
+        </div>`);
+      markerLayersRef.current.push(marker);
+    });
+
+    if (youLayerRef.current) {
+      try { youLayerRef.current.remove(); } catch {}
+      youLayerRef.current = null;
+    }
+
+    if (userLocation) {
+      const youIcon = L.divIcon({
+        className: 'you-marker',
+        html: `
+          <div style="display:flex;flex-direction:column;align-items:center;">
+            <div style="width:10px;height:10px;background:#2E523A;border:2px solid #fff;border-radius:999px;"></div>
+            <div style="margin-top:4px;background:rgba(255,255,255,.9);padding:2px 6px;border-radius:999px;border:1px solid #e5e7eb;font-size:10px;font-weight:600;color:#374151;">
+              You
+            </div>
+          </div>
+        `,
+      });
+      youLayerRef.current = L.marker([userLocation.latitude, userLocation.longitude], { icon: youIcon }).addTo(map);
+      if (recenterKey > 0) {
+        map.setView([userLocation.latitude, userLocation.longitude], 16, { animate: false });
+      }
+    }
+  }, [containers, userLocation, recenterKey, iconUrl]);
+
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    const L = leafletRef.current;
+    if (!map || !L || !map._container || !map._loaded) return;
+
+    if (routeLayerRef.current) {
+      try { routeLayerRef.current.remove(); } catch {}
+      routeLayerRef.current = null;
+    }
+
+    if (!routePath || routePath.length < 2) return;
+
+    const latLngs = routePath.map((p) => [p.latitude, p.longitude]);
+    const polyline = L.polyline(latLngs, { color: '#2E523A', weight: 4, opacity: 0.9 });
+    polyline.addTo(map);
+    routeLayerRef.current = polyline;
+
+    const bounds = polyline.getBounds?.();
+    if (bounds?.isValid?.()) {
+      try {
+        map.fitBounds(bounds, { padding: [30, 30], maxZoom: 17, animate: false });
+      } catch {
+        // ignore
+      }
+    }
+  }, [routePath]);
+
+  useEffect(() => {
+    if (recenterKey > 0) skipBoundaryFitRef.current = true;
+  }, [recenterKey]);
 
   return (
     <View style={styles.wrap}>

--- a/lib/components/WasteIcon.tsx
+++ b/lib/components/WasteIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+interface WasteIconProps {
+  size?: number;
+  color?: string;
+}
+
+const WasteIcon: React.FC<WasteIconProps> = ({ size = 28, color = '#355842' }) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <Path
+      fill={color}
+      d="M9 2L8 3H4V5H20V3H16L15 2H9ZM5 7V21C5 22.1 5.9 23 7 23H17C18.1 23 19 22.1 19 21V7H5ZM9 9H11V21H9V9ZM13 9H15V21H13V9Z"
+    />
+  </Svg>
+);
+
+export default WasteIcon;

--- a/lib/utils/boundaryCache.ts
+++ b/lib/utils/boundaryCache.ts
@@ -1,0 +1,74 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const CACHE_PREFIX = 'sibol.boundary.';
+const TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+const storage = {
+  async getItem(key: string): Promise<string | null> {
+    try {
+      if (AsyncStorage && typeof AsyncStorage.getItem === 'function') {
+        return await AsyncStorage.getItem(key);
+      }
+    } catch {
+      // ignore
+    }
+    try {
+      if (typeof localStorage !== 'undefined') {
+        return localStorage.getItem(key);
+      }
+    } catch {
+      // ignore
+    }
+    return null;
+  },
+  async setItem(key: string, value: string): Promise<void> {
+    try {
+      if (AsyncStorage && typeof AsyncStorage.setItem === 'function') {
+        await AsyncStorage.setItem(key, value);
+        return;
+      }
+    } catch {
+      // ignore
+    }
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(key, value);
+      }
+    } catch {
+      // ignore
+    }
+  },
+};
+
+function hashString(input: string): string {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 33) ^ input.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(16);
+}
+
+function cacheKey(query: string): string {
+  return `${CACHE_PREFIX}${hashString(query)}`;
+}
+
+export async function getCachedBoundary(query: string): Promise<any | null> {
+  const key = cacheKey(query);
+  const raw = await storage.getItem(key);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as { ts: number; feature: any };
+    if (!parsed || typeof parsed.ts !== 'number') return null;
+    if (Date.now() - parsed.ts > TTL_MS) return null;
+    return parsed.feature ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setCachedBoundary(query: string, feature: any): Promise<void> {
+  const key = cacheKey(query);
+  const payload = JSON.stringify({ ts: Date.now(), feature });
+  await storage.setItem(key, payload);
+}


### PR DESCRIPTION
Introduce container focus & routing features and add cached boundary overlays for maps. Key changes: add routePath/focusCoords state and UI (modal list, focus/redirect actions, path toggle) in HMap and OMap; draw route polylines and fit/map animate on native and web map components; fetch and cache OSM polygon boundaries (barangay queries) and render as Polygon/GeoJSON layers; add WasteIcon component and boundaryCache util for caching; adjust nearest-container logic to use activeContainer; simplify schedule UI in OSchedule to show every-2-day sample dates. Also include various small UI/UX improvements (path status badges, map centering behavior, leaflet tweaks).