### PR TITLE
Load and display waste inputs in OProcessDetails

### DIFF
--- a/lib/Pages/oProcess.tsx
+++ b/lib/Pages/oProcess.tsx
@@ -172,7 +172,7 @@ export default function OProcess() {
         return <OProcessSensors />;
 
       case 'Process Details':
-        return <OProcessDetails machineId={selectedMachine} />;
+        return <OProcessDetails machineId={selectedMachineId} machineName={selectedMachine?.Name} />;
 
       default:
         return null;

--- a/lib/services/wasteInputService.ts
+++ b/lib/services/wasteInputService.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { post } from './apiClient';
+import { get, post } from './apiClient';
 
 export async function createWasteInput(machineId: number | string, weight: number, accountId?: number | string) {
   let resolvedAccountId: number | undefined;
@@ -31,4 +31,13 @@ export async function createWasteInput(machineId: number | string, weight: numbe
 
   const data = await post('/api/waste-inputs', payload);
   return data;
+}
+
+export async function getWasteInputsByMachineId(machineId: number | string) {
+  const id = Number(machineId);
+  if (!Number.isFinite(id)) return [];
+  const data = await get(`/api/waste-inputs/machine/${id}`);
+  if (data && Array.isArray((data as any).data)) return (data as any).data;
+  if (Array.isArray(data)) return data;
+  return [];
 }


### PR DESCRIPTION
Pass machineName from OProcess and extend OProcessDetails to fetch and render real waste inputs. Added getWasteInputsByMachineId to wasteInputService and imported get in the service. OProcessDetails: accept machineId (number|string|null) and machineName, fetch inputs on machineId change, show loading indicator, filter inputs by Today/Week/Month via useMemo, parse/format dates, and render input cards (machine id, operator, weight) instead of the previous mock details. Includes safe fallbacks when no data or invalid IDs are present.